### PR TITLE
qasm3 parser: Support indexing classical arrays with variables

### DIFF
--- a/mlir/parsers/qasm3/tests/test_declaration.cpp
+++ b/mlir/parsers/qasm3/tests/test_declaration.cpp
@@ -80,6 +80,22 @@ for i in [0:22] {
   EXPECT_TRUE(qcor::execute(src2, "test"));
 }
 
+TEST(qasm3VisitorTester, checkCregAddressingWithMemref) {
+  const std::string broadcast = R"#(OPENQASM 3;
+include "qelib1.inc";
+int[32] i = 2;
+const j = 1;
+bit b[4] = "0101";
+
+QCOR_EXPECT_TRUE(b[i] == 0);
+QCOR_EXPECT_TRUE(b[j] == 1);
+)#";
+  auto mlir = qcor::mlir_compile(broadcast, "creg_memref_addressing",
+                                 qcor::OutputType::MLIR, false);
+
+  EXPECT_FALSE(qcor::execute(broadcast, "creg_memref_addressing"));
+}
+
 TEST(qasm3VisitorTester, checkGate) {
   const std::string gate_def = R"#(OPENQASM 3;
 gate cphase(x) a, b

--- a/mlir/parsers/qasm3/utils/expression_handler.cpp
+++ b/mlir/parsers/qasm3/utils/expression_handler.cpp
@@ -205,6 +205,11 @@ antlrcpp::Any qasm3_expression_generator::visitTerminal(
         indexed_variable_name = "";
       } else {
         // We are loading from a variable
+
+        if (current_value.getType().isa<mlir::MemRefType>()) {
+          current_value = builder.create<mlir::LoadOp>(location, current_value);
+        }
+
         llvm::ArrayRef<mlir::Value> idx(cast_array_index_value_if_required(
             indexed_variable_value.getType(), current_value, location,
             builder));


### PR DESCRIPTION
This is my attempt at fixing #251. Currently, writing the following OpenQASM 3:

    const pos = 2;
    bit c[4];
    print(c[pos]);

generates the following invalid MLIR:

    %3 = index_cast %1 : memref<ui32> to index

Instead, we need to load the memref first:

    %3 = load %1[] : memref<i64>
    %4 = index_cast %3 : i64 to index

Add a check and a unit test for this.

### Testing
I added a unit test for this and ran the unit tests with `ctest` (some unrelated QJIT tests failed with linker errors, but they also failed on `master` for me). I also manually tested with the code from #251 as well as using a constant which could trigger the same problem:

```
OPENQASM 3;

const pos = 2;
bit c[4] = "0101";
print(c[pos]);
```