### PR TITLE
Pass ancilla buffer to XACC even if user passes multiple qregs

### DIFF
--- a/runtime/qrt/impls/nisq/nisq_qrt.cpp
+++ b/runtime/qrt/impls/nisq/nisq_qrt.cpp
@@ -392,9 +392,8 @@ class NISQ : public ::quantum::QuantumRuntime,
     auto anc_allocator = NisqQubitAllocator::getInstance();
     if (anc_allocator->get_buffer() &&
         anc_allocator->get_buffer()->size() > 0) {
-      std::vector<xacc::AcceleratorBuffer *> buffer_list{
-          buffer, anc_allocator->get_buffer().get()};
-      submit(buffer_list.data(), buffer_list.size());
+      // submit(AcceleratorBuffer**, ...) will add the ancilla buffer on its own
+      submit(&buffer, 1);
     } else {
       if (__print_final_submission) {
         std::cout << "==== NISQ JOB SUBMISSION ====\n";
@@ -467,7 +466,9 @@ class NISQ : public ::quantum::QuantumRuntime,
         os.close();
       }
     }
-    xacc::internal_compiler::execute(buffers, nBuffers, program->as_xacc());
+
+    std::vector<xacc::AcceleratorBuffer *> buffer_list(ptrs.begin(), ptrs.end());
+    xacc::internal_compiler::execute(buffer_list.data(), buffer_list.size(), program->as_xacc());
   }
 
   void set_current_program(std::shared_ptr<CompositeInstruction> p) override {


### PR DESCRIPTION
This is an attempt to address the Quantum++ backend receiving out-of-range qubit indices in some cases. For example, due to using a different code path, this code works (thanks to Akihiro for both examples):

    #include <qcor_arithmetic>

    __qpu__ void CUa(qreg x, int a, int N) {
        // c = |1>
        qreg c = qalloc(1);
        X(c[0]);
        // x = |3>
        X(x[0]);
        X(x[1]);
        mul_integer_mod_in_place::ctrl(c, x, a, N);
        Measure(x);
    }

    int main() {
        set_verbose(true);
        int a = 1;
        int N = 2;
        set_shots(2);
        auto x = qalloc(2);
        CUa(x, a, N);
        x.print();
    }

Yet this code throws a runtime error:

    #include <qcor_arithmetic>

    __qpu__ void CUa(qreg x, qreg c, int a, int N) {
        // c = |1>
        X(c[0]);
        // x = |3>
        X(x[0]);
        X(x[1]);
        mul_integer_mod_in_place::ctrl(c, x, a, N);
        Measure(x);
    }

    int main() {
        set_verbose(true);
        int a = 1;
        int N = 2;
        set_shots(2);
        auto x = qalloc(2);
        auto c = qalloc(1);
        CUa(x, c, a, N);
        x.print();
    }

Specifically, the error was:

    terminate called after throwing an instance of 'qpp::exception::MatrixMismatchSubsys'
      what():  In qpp::apply(): Matrix mismatch subsystems!

Or with XACC built with debug mode, the following assertion is tripped beforehand:

    .../xacc/quantum/plugins/qpp/accelerator/QppVisitor.cpp:96: qpp::idx xacc::quantum::QppVisitor::xaccIdxToQppIdx(size_t) const: Assertion `in_idx < m_buffer->size()' failed.

With this change, this issue no longer occurs because the ancilla buffer is passed for `xacc::internal_compiler::execute()`. Before, `xacc::internal_compiler::execute()` noticed that some instructions were referencing an AcceleratorBuffer `aux_temp_buffer` not in the list of buffers passed to it and tried to recreate one, but that apparently failed to prevent some misbehavior in this case.

### Testing
Ran those two examples above, both of which worked. Also ran the unit tests via `ctest`, and no new tests failed compared to master